### PR TITLE
feat(#2): support for extra manifest fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ For more details on what each handler should return see the official SDK's [prot
 
 Similar to the official SDK, this package also allows you to open a web version of Stremio with your addon pre-installed.
 
-You can either do it via CLI with:
+You can either do via CLI with:
 
 ```bash
 npx stremio-rewired launch
@@ -94,9 +94,9 @@ The typical workflow locally is to launch the extension along with your dev serv
 }
 ```
 
-### Launching programmatically
+### Launching Stremio programmatically
 
-You can import the `launch` function and run it anywhere you want. This will open your default browser on Stremio with your addon installed.
+You can also import the `launch` function and run it anywhere you want instead of using the CLI. This will open your default browser on Stremio with your addon installed.
 
 ```ts
 import { launch } from "stremio-rewired/launch";
@@ -106,4 +106,47 @@ if (process.env.NODE_ENV === "development") {
   // be the same as your dev server port.
   launch(3000);
 }
+```
+
+## Goodies
+
+### Custom manifest fields
+
+You can extend the Manifest object by providing a generic to `createHandler`:
+
+```ts
+const handler = createHandler<{
+  myCustomField: string;
+}>({
+  manifest: {
+    id: "org.stremio.my-addon",
+    version: "0.0.2",
+    name: "My Addon",
+    description: "This is a cool addon",
+    // rest of manifest
+    myCustomField: "test",
+  },
+});
+```
+
+This is useful for integrating with third-party services that require custom fields in the manifest:
+
+```ts
+const handler = createHandler<{
+  stremioAddonsConfig: {
+    issuer: string;
+    signature: string;
+  };
+}>({
+  manifest: {
+    id: "org.stremio.my-addon",
+    version: "0.0.2",
+    name: "My Addon",
+    description: "This is a cool addon",
+    stremioAddonsConfig: {
+      issuer: "https://stremio-addons.net",
+      signature: "some-signature",
+    },
+  },
+});
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -100,7 +100,7 @@ function hasResource(
   });
 }
 
-export function createHandler(config: Config) {
+export function createHandler<T>(config: Config<T>) {
   const logger = createConsola({
     defaults: {
       tag: "stremio-rewired",

--- a/src/types.ts
+++ b/src/types.ts
@@ -103,7 +103,7 @@ export type ConfigField = {
   required?: boolean;
 };
 
-export type Manifest = {
+export type Manifest<T = {}> = {
   id: string;
   description: string;
   version: string;
@@ -118,7 +118,7 @@ export type Manifest = {
   logo?: string;
   contactEmail?: string;
   addonCatalogs?: AddonCatalogDefinition[];
-};
+} & T;
 
 export type CatalogItem = {
   id: string;
@@ -212,8 +212,8 @@ export type AddonCatalogResponse = {
   addons: AddonCatalogItem[];
 } & CacheHeaders;
 
-export type Config = {
-  manifest: Manifest;
+export type Config<T = {}> = {
+  manifest: Manifest<T>;
   onStreamRequest?: (
     type: ContentType,
     id: string,


### PR DESCRIPTION
Adds support for custom extra Manifest fields at the type level.

This is useful in case the Stremio protocol gets updated and the library is out of date, but most importantly it allows integration with third-party tools that make us of custom manifest fields (such as stremio-addons.net)

Adding custom fields was already supported but led to a type error. This fixes it by allowing the extension of the manifest type via generics.

Like so:

```ts
const handler = createHandler<{
  myCustomField: string;
}>({
  manifest: {
     myCustomField: "foo"
  }
});
```
